### PR TITLE
Enable auto-building viewer.js, add developer docs to README

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,13 @@
+# This guardfile watches for changes to src/*.coffee, rebuilds viewer.js,
+# and copies it into the examples directory so you can automatically
+# see your changes.
+
+notification :off
+
+guard :shell do
+  watch(%r{^src/.+\.coffee$}) { |m|
+    `cake build`
+    `cp lib/viewer.js example/js`
+  }
+end
+

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ And that's it, we're all done! All we have left to do is paint the whole thing t
 
 ## Developing
 
-You'll need a javascript runtime (node.js should work great) and CoffesScript. Node should give you the 'cake' build system. To compile all of src/*coffee into lib/viewer.js, run:
+You'll need a javascript runtime (node.js should work great) and CoffesScript. Node should give you the `cake` build system. To compile all of src/*coffee into lib/viewer.js, run:
 
 	cake build
+
+To view the examples, the simplest way is probably to go into the examples directory, run:
+
+	python -m SimpleHTTPServer 8888
+
+and point your browser to http://localhost:8888.
+
+For automated building and copying the updated viewer.js to your examples directory (recommended!), install the `guard` and `guard-shell` ruby gems, and run:
+
+	guard


### PR DESCRIPTION
Add a Guardfile, which will auto-build viewer.js and put it in your examples dir.

Also add some simple developer docs to README.md
