### PR TITLE
Add colorbrewer schemes

### DIFF
--- a/example/js/viewer.js
+++ b/example/js/viewer.js
@@ -1273,6 +1273,9 @@
     }
 
     $.extend(ColorMap.PALETTES, {
+      'intense red-blue': ['#053061', '#2166AC', '#4393C3', '#F7F7F7', '#D6604D', '#B2182B', '#67001F'],
+      'red-yellow-blue': ['#313695', '#4575B4', '#74ADD1', '#FFFFBF', '#F46D43', '#D73027', '#A50026'],
+      'brown-teal': ['#003C30', '#01665E', '#35978F', '#F5F5F5', '#BF812D', '#8C510A', '#543005'],
       'hot and cold': ['aqua', '#0099FF', 'blue', 'white', 'red', 'orange', 'yellow'],
       'bright lights': ['blue', 'red', 'yellow', 'green', 'purple'],
       terrain: ['#006400', 'green', 'lime', 'yellow', '#b8860b', '#cd853f', '#ffc0cb', 'white']

--- a/lib/viewer.js
+++ b/lib/viewer.js
@@ -1273,6 +1273,9 @@
     }
 
     $.extend(ColorMap.PALETTES, {
+      'intense red-blue': ['#053061', '#2166AC', '#4393C3', '#F7F7F7', '#D6604D', '#B2182B', '#67001F'],
+      'red-yellow-blue': ['#313695', '#4575B4', '#74ADD1', '#FFFFBF', '#F46D43', '#D73027', '#A50026'],
+      'brown-teal': ['#003C30', '#01665E', '#35978F', '#F5F5F5', '#BF812D', '#8C510A', '#543005'],
       'hot and cold': ['aqua', '#0099FF', 'blue', 'white', 'red', 'orange', 'yellow'],
       'bright lights': ['blue', 'red', 'yellow', 'green', 'purple'],
       terrain: ['#006400', 'green', 'lime', 'yellow', '#b8860b', '#cd853f', '#ffc0cb', 'white']

--- a/src/views.coffee
+++ b/src/views.coffee
@@ -356,6 +356,9 @@ class ColorMap
     @PALETTES[col] = ['black', col, 'white']
   # Add some other palettes
   $.extend(@PALETTES, {
+    'intense red-blue': ['#053061', '#2166AC', '#4393C3', '#F7F7F7', '#D6604D', '#B2182B', '#67001F']
+    'red-yellow-blue': ['#313695', '#4575B4', '#74ADD1', '#FFFFBF', '#F46D43', '#D73027', '#A50026']
+    'brown-teal': ['#003C30', '#01665E', '#35978F', '#F5F5F5', '#BF812D', '#8C510A', '#543005']
     'hot and cold': ['aqua', '#0099FF', 'blue', 'white', 'red', 'orange', 'yellow']
     'bright lights': ['blue', 'red', 'yellow', 'green', 'purple']
     terrain: ['#006400', 'green', 'lime', 'yellow', '#b8860b', '#cd853f', '#ffc0cb', 'white']


### PR DESCRIPTION
This adds three color schemes that work at least vaguely well from ColorBrewer.

I'd probably keep at most two (the "intense red-blue" is probably best).

I'd also advocate ditching the "Bright Lights" and "Terrain" schemes -- though those changes are not in this pull request
