### PR TITLE
Switch to ndarray and collapse layers

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -57,12 +57,12 @@ window.Viewer = class Viewer
       v.clear()
       # Paint all layers. Note the reversal of layer order to ensure 
       # top layers get painted last.
-      for l in @layerList.layers.slice(0).reverse()
-        v.paint(l) if l.visible
+      v.paint(@layerList.layers.slice(0).reverse())
+
       # v.paint((l for l in @layerList.layers.slice(0).reverse() if l.visible))
       v.drawCrosshairs()
       v.drawLabels()
-    $(@).trigger("beforePaint")
+    $(@).trigger("afterPaint")
     return true
 
 

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -1,4 +1,5 @@
-
+ndarray = require('ndarray')
+ops = require('ndarray-ops')
 window.Viewer or= {}
 
 ### VARIOUS HELPFUL FUNCTIONS ###
@@ -316,9 +317,9 @@ window.Viewer = class Viewer
       [x, y, z] = coords
     else
       [x, y, z] = @coords_ijk
-    return (l.image.data[z][y][x] for l in @layerList.layers) if all
+    return (l.image.data.get(z, y, x) for l in @layerList.layers) if all
     layer = if layer? then @layerList.layers[layer] else @layerList.activeLayer
-    layer.image.data[z][y][x]
+    layer.image.data.get(z, y, x)
 
   # Takes dimension and x/y as input and returns x/y/z viewer coordinates
   viewer2dTo3d: (dim, cx, cy = null) ->

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -46,7 +46,7 @@ class Image
         for k in [-r..r]
           continue if (z-k) < 0 or (z+k) > (@z - 1)
           dist = i*i + j*j + k*k
-          @data[i+x][j+y][k+z] = value if dist < r*r
+          @data.set(i+x, j+y, k+z, value) if dist < r*r
     return false
 
 

--- a/src/models.coffee
+++ b/src/models.coffee
@@ -151,20 +151,21 @@ class Layer
 
   # Update the layer's settings from provided object.
   update: (settings) ->
+
     # Handle settings that take precedence first
     @sign = settings['sign'] if 'sign' of settings
 
-    # Now everything else
+    # Now everything else--ignoring settings that haven't changed
     nt = 0
     pt = 0
     for k, v of settings
       switch k
-        when 'colorPalette' then @setColorMap(v)
-        when 'opacity' then @opacity = v
-        when 'image-intent' then @intent = v
+        when 'colorPalette' then @setColorMap(v) if @palette != v
+        when 'opacity' then @opacity = v if @opacity != v
+        when 'image-intent' then @intent = v if @intent != v
         when 'pos-threshold' then pt = v
         when 'neg-threshold' then nt = v
-        when 'description' then @description = v
+        when 'description' then @description = v if @description != v
     @setThreshold(nt, pt, @sign)
 
 
@@ -295,7 +296,6 @@ class ColorMap
     (if hex.length is 1 then "0" + hex else hex)
 
   @rgbToHex = (rgb) ->
-    # console.log(rgb)
     "#" + componentToHex(rgb[0]) + componentToHex(rgb[1]) + componentToHex(rgb[2])
 
   # For now, palettes are hard-coded. Should eventually add facility for

--- a/src/views.coffee
+++ b/src/views.coffee
@@ -273,7 +273,6 @@ class View
 
   paint: (layer) ->
 
-    # start = new Date().getTime()
     @resetCanvas() if @width == 0 # Make sure canvas is visible
     data = layer.slice(this, @viewer)
     cols = layer.colorMap.map(data)

--- a/src/views.coffee
+++ b/src/views.coffee
@@ -282,7 +282,11 @@ class View
     @context.lineWidth = 1
 
     @resetCanvas() if @width == 0 # Make sure canvas is visible
-    data = (l.slice(@dim) for l in layers)
+    data = []
+    for l in layers
+      ld = l.slice(@dim)
+      ld = l.threshold.mask(ld)
+      data.push(l.colorMap.map(ld))
     for i in [0...data[0].shape[0]]
       for j in [0...data[0].shape[1]]
         vox_rgb = []
@@ -291,17 +295,17 @@ class View
           for l, n in layers
             if l.visible
               _val = data[n].get(i, j, c)
-              continue if !_val?
-              val = (_val * 1.0 * l.opacity) + (1.0 - l.opacity) * val
+              continue if isNaN(_val)
+              val = (_val * l.opacity) + (1.0 - l.opacity) * val
+          val = Math.round(val)
           val = 0 if val < 0
           val = 255 if val > 255
           vox_rgb[c] = val
-        vox_hex = ColorMap.rgbToHex(vox_rgb)
 
         # Paint
         xp = @width - (j + 1) * xCell
         yp = @height - (i + 1) * yCell
-        @context.fillStyle = vox_hex
+        @context.fillStyle = 'rgb(' + vox_rgb.join(', ') + ')'
         @context.fillRect xp, yp, xCell+fuzz, yCell+fuzz
 
     if @slider?

--- a/src/views.coffee
+++ b/src/views.coffee
@@ -289,10 +289,12 @@ class View
     # start = new Date().getTime()
     for i in [0...dims[@dim][1]]
       for j in [0...dims[@dim][0]]
-        continue if typeof data[i][j] is `undefined` | data[i][j] is 0
+        # continue if typeof data[i][j] is `undefined` | data[i][j] is 0
+        continue if typeof data.get(i, j) is `undefined` | data.get(i, j) is 0
         xp = @width - (j + 1) * xCell #- xCell
         yp = @height - (i + 1) * yCell
-        col = cols[i][j]
+        # col = cols[i][j]
+        col = cols.get(i, j)
         @context.fillStyle = col
         @context.fillRect xp, yp, xCell+fuzz, yCell+fuzz
     @context.globalAlpha = 1.0
@@ -461,11 +463,12 @@ class ColorMap
   # Map values to colors. Currently uses a linear mapping;  could add option
   # to use other methods.
   map: (data) ->
-    res = []
-    for i in [0...data.length]
-      res[i] = data[i].map (v) =>
-        # hexToRgb(@colors[Math.floor(((v-@min)/@range) * @steps)])
-        @colors[Math.floor(((v-@min)/@range) * @steps)]
+    res = ndarray(new Array(data.size), data.shape)
+    for i in [0...data.shape[0]]
+      for j in [0...data.shape[1]]
+        v = data.get(i, j)
+        val = @colors[Math.floor(((v-@min)/@range) * @steps)]
+        res.set(i, j, val)
     return res
 
 

--- a/src/views.coffee
+++ b/src/views.coffee
@@ -437,53 +437,6 @@ class Crosshairs
 
 
 
-class ColorMap
-
-  # For now, palettes are hard-coded. Should eventually add facility for
-  # reading in additional palettes from file and/or creating them in-browser.
-  @PALETTES =
-    grayscale: ['#000000','#303030','gray','silver','white']
-  # Add monochrome palettes
-  basic = ['red', 'green', 'blue', 'yellow', 'purple', 'lime', 'aqua', 'navy']
-  for col in basic
-    @PALETTES[col] = ['black', col, 'white']
-  # Add some other palettes
-  $.extend(@PALETTES, {
-    'intense red-blue': ['#053061', '#2166AC', '#4393C3', '#F7F7F7', '#D6604D', '#B2182B', '#67001F']
-    'red-yellow-blue': ['#313695', '#4575B4', '#74ADD1', '#FFFFBF', '#F46D43', '#D73027', '#A50026']
-    'brown-teal': ['#003C30', '#01665E', '#35978F', '#F5F5F5', '#BF812D', '#8C510A', '#543005']
-  })
-
-  
-  constructor: (@min, @max, @palette = 'hot and cold', @steps = 40) ->
-    @range = @max - @min
-    @colors = @setColors(ColorMap.PALETTES[@palette])
-
-
-  # Map values to colors. Currently uses a linear mapping;  could add option
-  # to use other methods.
-  map: (data) ->
-    res = ndarray(new Array(data.size), data.shape)
-    for i in [0...data.shape[0]]
-      for j in [0...data.shape[1]]
-        v = data.get(i, j)
-        val = @colors[Math.floor(((v-@min)/@range) * @steps)]
-        res.set(i, j, val)
-    return res
-
-
-  # Takes a set of discrete color names/descriptions and remaps them to
-  # a space with @steps different colors.
-  setColors: (colors) ->
-    rainbow = new Rainbow()
-    rainbow.setNumberRange(1, @steps)
-    rainbow.setSpectrum.apply(null, colors)
-    colors = []
-    colors.push rainbow.colourAt(i) for i in [1...@steps]
-    return colors.map (c) -> "#" + c
-
-
-
 class Component
 
   constructor: (@container, @name, @element) ->


### PR DESCRIPTION
This PR closes #21 and #22. We switch from representing volumes as arrays-of-arrays-of-arrays to using 3D ndarrays. This provides a modest performance boost and enables much more compact code via modular plugins like ndarray-ops.

We also now collapse all layers before painting--i.e., instead of painting each layer separately to canvas, we alpha composite all layers into a single rgb ndarray, then blit the result to canvas once. This takes us from O(n) to nearly O(1) time as a function of number of layers loaded.

Note: we're now drawing on node libraries (ndarray and ndarray-ops); this is probably a good time to switch the other dependencies out too and use a more general packaging solution (e.g., browserify).
